### PR TITLE
GIPC: Introduce G-stage table In Process Context (GIPC)

### DIFF
--- a/packages/rv_iommu/rv_iommu_pkg.sv
+++ b/packages/rv_iommu/rv_iommu_pkg.sv
@@ -108,7 +108,8 @@ package rv_iommu;
     // Translation Control
    typedef struct packed {
         logic [31:0]    reserved_2;
-        logic [7:0]     custom;
+        logic [6:0]     custom;
+        logic           gipc;
         logic [11:0]    reserved_1;
         logic           sxl;
         logic           sbe;
@@ -164,6 +165,7 @@ package rv_iommu;
     typedef struct packed {
         fsc_t   fsc;
         pc_ta_t ta;
+        iohgatp_t iohgatp;
     } pc_t;
 
     //--------------------------
@@ -369,7 +371,8 @@ package rv_iommu;
 
     // Capabilities (caps)
     typedef struct packed {
-        logic [7:0]     custom;
+        logic [6:0]     custom;
+        logic           gipc;
         logic [14:0]    reserved_3;
         logic           pd20;
         logic           pd17;

--- a/packages/rv_iommu/rv_iommu_reg_pkg.sv
+++ b/packages/rv_iommu/rv_iommu_reg_pkg.sv
@@ -100,6 +100,9 @@ package rv_iommu_reg_pkg;
     struct packed {
       logic        q;
     } pd20;
+    struct packed {
+      logic        q;
+    } gipc;
   } iommu_reg2hw_capabilities_reg_t;
 
   typedef struct packed {

--- a/rtl/software_interface/regmap/rv_iommu_regmap.sv
+++ b/rtl/software_interface/regmap/rv_iommu_regmap.sv
@@ -124,6 +124,7 @@ module rv_iommu_regmap #(
   logic 		    capabilities_pd8_qs;
   logic 		    capabilities_pd17_qs;
   logic 		    capabilities_pd20_qs;
+  logic 		    capabilities_gipc_qs;
 
   // fctl
   logic 		    fctl_be_qs;
@@ -528,6 +529,9 @@ module rv_iommu_regmap #(
   assign reg2hw.capabilities.pd20.q = 1'h1;
   assign capabilities_pd20_qs = 1'h1;
 
+  //   F[gipc]: 56:56
+  assign reg2hw.capabilities.gipc.q = 1'h1;
+  assign capabilities_gipc_qs = 1'h1;
 
   // R[fctl]: V(False)
 
@@ -3251,7 +3255,9 @@ module rv_iommu_regmap #(
         reg_rdata_next[6]     = capabilities_pd8_qs;
         reg_rdata_next[7]     = capabilities_pd17_qs;
         reg_rdata_next[8]     = capabilities_pd20_qs;
-        reg_rdata_next[31:9]  = '0;
+        reg_rdata_next[23:9]  = '0;
+        reg_rdata_next[24]    = capabilities_gipc_qs;
+        reg_rdata_next[31:25] = '0;
       end
 
       // fctl

--- a/rtl/translation_logic/cdw/rv_iommu_cdw_pc.sv
+++ b/rtl/translation_logic/cdw/rv_iommu_cdw_pc.sv
@@ -52,6 +52,7 @@ module rv_iommu_cdw_pc #(
     input  logic        caps_msi_flat_i,
     input  logic        caps_amo_hwad_i,
     input  logic        caps_end_i, fctl_be_i,
+    input  logic        caps_gipc_i,
 
     // PC checks
     input  logic        dc_sxl_i,
@@ -85,6 +86,7 @@ module rv_iommu_cdw_pc #(
 
     // from DC (for PC walks)
     input  logic                    en_stage2_i,    // Second-stage translation is enabled
+    input  logic                    gipc_i,         // GIPC is enabled
     input  logic [riscv::PPNW-1:0]  pdtp_ppn_i,     // PPN from DC.fsc.PPN
     input  logic [3:0]              pdtp_mode_i,    // PDT levels from DC.fsc.MODE
 
@@ -110,6 +112,7 @@ module rv_iommu_cdw_pc #(
 
     rv_iommu::pc_ta_t   pc_ta_q,    pc_ta_n;
     rv_iommu::fsc_t     pc_fsc_q,   pc_fsc_n;
+    rv_iommu::iohgatp_t pc_iohgatp_q,   pc_iohgatp_n;
 
     // DDTC / PDTC Update
     assign up_did_o = device_id_q;
@@ -118,6 +121,7 @@ module rv_iommu_cdw_pc #(
 
     assign up_pc_content_o.ta   = pc_ta_q;
     assign up_pc_content_o.fsc  = pc_fsc_q;
+    assign up_pc_content_o.iohgatp  = pc_iohgatp_q;
 
     // Cast read port to corresponding data structure
     rv_iommu::tc_t          dc_tc;
@@ -127,6 +131,7 @@ module rv_iommu_cdw_pc #(
 
     rv_iommu::pc_ta_t       pc_ta;
     rv_iommu::fsc_t         pc_fsc;
+    rv_iommu::iohgatp_t     pc_iohgatp;
 
     rv_iommu::nl_entry_t    nl;
 
@@ -137,6 +142,7 @@ module rv_iommu_cdw_pc #(
     
     assign pc_ta = rv_iommu::pc_ta_t'(mem_resp_i.r.data);
     assign pc_fsc = rv_iommu::fsc_t'(mem_resp_i.r.data);
+    assign pc_iohgatp = rv_iommu::iohgatp_t'(mem_resp_i.r.data);
 
     assign nl = rv_iommu::nl_entry_t'(mem_resp_i.r.data);
 
@@ -192,13 +198,17 @@ module rv_iommu_cdw_pc #(
     // Signal MSI field config error to main FSM
     logic msi_check_error;
 
+    // Enable en_stage2
+    logic en_stage2;
+    assign en_stage2 = !gipc_i && en_stage2_i;
+
     // PTW walking
     assign cdw_active_o     = (state_q != IDLE);
     // Last CDW level
     assign is_last_cdw_lvl  = (cdw_lvl_q == LVL1);
     // Determine whether we have loaded the entire DC/PC
     assign dc_fully_loaded  = (MSITrans != rv_iommu::MSI_DISABLED) ? (entry_cnt_q == 3'b111) : (entry_cnt_q == 3'b100);  // extended format w/out reserved DW (64-8 = 56 bytes)
-    assign pc_fully_loaded  = (entry_cnt_q == 3'b010);  // always 16-bytes
+    assign pc_fully_loaded  = (gipc_i ? entry_cnt_q == 3'b011 : entry_cnt_q == 3'b010);  // always 16-bytes, but (32-8 = 24) bytes for GIPC
     // PTW needs to know walk type to identify pdtp.PPN translations and select correct iohgatp source
     assign is_ddt_walk_o    = is_ddt_walk_q;
 
@@ -260,8 +270,8 @@ module rv_iommu_cdw_pc #(
         // AR
         mem_req_o.ar.id         = 4'b0001;                         
         mem_req_o.ar.addr       = {{riscv::XLEN-riscv::PLEN{1'b0}}, cdw_pptr_q};    // Physical address to access
-        // Number of beats per burst (1 for non-leaf entries, 2 for PC, 7 for DC)
-        mem_req_o.ar.len        = (is_last_cdw_lvl) ? ((is_ddt_walk_q) ? (ar_len) : (8'd1)) : (8'd0);
+        // Number of beats per burst (1 for non-leaf entries, 3/2 for PC, 7/4 for DC)
+        mem_req_o.ar.len        = (is_last_cdw_lvl) ? ((is_ddt_walk_q) ? (ar_len) : (gipc_i : (8'd2) : (8'd1))) : (8'd0);
         mem_req_o.ar.size       = 3'b011;                                           // 64 bits (8 bytes) per beat
         mem_req_o.ar.burst      = axi_pkg::BURST_INCR;                              // Incremental start address
         mem_req_o.ar.lock       = '0;
@@ -300,6 +310,7 @@ module rv_iommu_cdw_pc #(
         dc_fsc_n                = dc_fsc_q;
         pc_ta_n                 = pc_ta_q;
         pc_fsc_n                = pc_fsc_q;
+        pc_iohgatp_n            = pc_iohgatp_q;
 
         case (state_q)
 
@@ -347,13 +358,18 @@ module rv_iommu_cdw_pc #(
                     // load pptr according to pdtp.MODE
                     // PD20
                     if (pdtp_mode_i == 4'b0011)
-                        cdw_pptr_n = {pdtp_ppn_i, 6'b0, req_pid_i[19:17], 3'b0};    // ... aaaa 0000 00bb b000
+                        cdw_pptr_n = {pdtp_ppn_i,
+                                      gipc_i ? 5'b0 : 6'b0,
+                                      gipc_i ? req_pid_i[19:16] : req_pid_i[19:17], 3'b0};
                     // PD17
                     else if (pdtp_mode_i == 4'b0010)
-                        cdw_pptr_n = {pdtp_ppn_i, req_pid_i[16:8], 3'b0};           // ... aaaa bbbb bbbb b000
+                        cdw_pptr_n = {pdtp_ppn_i,
+                                      gipc_i ? req_pid_i[15:7] : req_pid_i[16:8], 3'b0};
                     // PD8
                     else if (pdtp_mode_i == 4'b0001)
-                        cdw_pptr_n = {pdtp_ppn_i, req_pid_i[7:0], 4'b0};             // ... aaaa bbbb bbbb 0000
+                        cdw_pptr_n = {pdtp_ppn_i,
+                                      gipc_i ? req_pid_i[6:0] : req_pid_i[7:0],
+                                      gipc_i ? 5'b0 : 4'b0};
                 end
             end
 
@@ -372,7 +388,7 @@ module rv_iommu_cdw_pc #(
                         - Is Stage-2 enabled?
                         - Is the last level of the DDT/PDT?
                     */
-                    case ({en_stage2_i, is_ddt_walk_q, is_last_cdw_lvl})
+                    case ({en_stage2, is_ddt_walk_q, is_last_cdw_lvl})
                         // rdata will hold the PPN of a non-leaf PDT/DDT entry
                         // Stage-2 is don't care for DC walks since iohgatp always provides a PPN
                         3'b000, 3'b010, 3'b110: begin
@@ -431,7 +447,7 @@ module rv_iommu_cdw_pc #(
                                                                     (MSITrans == rv_iommu::MSI_DISABLED) ? (device_id_q[15:7]) : (device_id_q[14:6]), 
                                                                         3'b0};
                                 else begin 
-                                    if (!en_stage2_i)   cdw_pptr_n = {nl.ppn, process_id_q[16:8], 3'b0};
+                                    if (!en_stage2)     cdw_pptr_n = {nl.ppn, gipc_i ? process_id_q[15:7] : process_id_q[16:8], 3'b0};
                                     else                cdw_pptr_n = {pdt_ppn_i, process_id_q[16:8], 3'b0};
                                 end
                             end
@@ -441,7 +457,7 @@ module rv_iommu_cdw_pc #(
                                 if (is_ddt_walk_q) cdw_pptr_n = {nl.ppn, 
                                                                     (MSITrans == rv_iommu::MSI_DISABLED) ? ({device_id_q[6:0], 5'b0}) : ({device_id_q[5:0], 6'b0})};
                                 else begin 
-                                    if (!en_stage2_i)   cdw_pptr_n = {nl.ppn, process_id_q[7:0], 4'b0};
+                                    if (!en_stage2)     cdw_pptr_n = {nl.ppn, gipc_i ? process_id_q[6:0] : process_id_q[7:0], gipc_i ? 5'b0 : 4'b0};
                                     else                cdw_pptr_n = {pdt_ppn_i, process_id_q[7:0], 4'b0};
                                 end
                             end
@@ -470,7 +486,7 @@ module rv_iommu_cdw_pc #(
                 end
 
                 // Last DW (When stage-2 is enabled we must verify if the DC has been updated with the translated pdtp.PPN)
-                if ((is_ddt_walk_q && dc_fully_loaded && (ptw_done_q || !en_stage2_i || !dc_tc_q.pdtv)) || 
+                if ((is_ddt_walk_q && dc_fully_loaded && (ptw_done_q || !en_stage2 || !dc_tc_q.pdtv)) ||
                     (!is_ddt_walk_q && pc_fully_loaded)) begin
 
                     state_n = IDLE;
@@ -520,6 +536,26 @@ module rv_iommu_cdw_pc #(
                                                  (!caps_sv48_i && pc_fsc.mode == 4'd9) ||
                                                  (!caps_sv57_i && pc_fsc.mode == 4'd10))) ||
                                 (dc_sxl_i && (!caps_sv32_i && pc_fsc.mode == 4'd8))) begin
+                                state_n = ERROR;
+                                cause_n = rv_iommu::PDT_ENTRY_MISCONFIGURED;
+                                if (gipc_i) begin
+                                    wait_rlast_n    = 1'b1;
+                                end
+                            end
+                        end
+
+                        //PC.iohgatp
+                        4'b0010: begin
+                            pc_iohgatp_n = pc_iohgatp;
+
+                            // Config checks
+                            if (!caps_gipc_i ||
+                                (!(pc_iohgatp.mode inside {4'd0, 4'd8, 4'd9, 4'd10})) ||
+                                (!fctl_gxl_i && ((!caps_sv39x4_i && pc_iohgatp.mode == 4'd8) ||
+                                                 (!caps_sv48x4_i && pc_iohgatp.mode == 4'd9) ||
+                                                 (!caps_sv57x4_i && pc_iohgatp.mode == 4'd10))) ||
+                                (fctl_gxl_i && (!caps_sv32x4_i && pc_iohgatp.mode == 4'd8)) ||
+                                (|pc_iohgatp.mode && |pc_iohgatp.ppn[1:0])) begin
                                 state_n = ERROR;
                                 cause_n = rv_iommu::PDT_ENTRY_MISCONFIGURED;
                             end
@@ -612,7 +648,7 @@ module rv_iommu_cdw_pc #(
                             else if (MSITrans == rv_iommu::MSI_DISABLED) begin
                                 // only if DC have an associated PC and Stage-2 is enabled, pdtp.PPN must be translated before being stored
                                 // otherwise, fsc.PPN holds iosatp field, which must be saved as a GPA
-                                if (en_stage2_i && dc_tc_q.pdtv)
+                                if (en_stage2 && dc_tc_q.pdtv)
                                     state_n = GUEST_TR;
                             end
                         end
@@ -806,7 +842,7 @@ module rv_iommu_cdw_pc #(
 
                             // only if DC have an associated PC and Stage-2 is enabled, pdtp.PPN must be translated before being stored
                             // otherwise, fsc.PPN holds iosatp field, which must be saved as a GPA
-                            if (en_stage2_i && dc_tc_q.pdtv) 
+                            if (en_stage2 && dc_tc_q.pdtv)
                                 translate_pdtp = 1'b1;
 
                             // Config checks
@@ -871,6 +907,7 @@ module rv_iommu_cdw_pc #(
             dc_fsc_q                <= '0;
             pc_ta_q                 <= '0;
             pc_fsc_q                <= '0;
+            pc_iohgatp_q            <= '0;
             ptw_done_q              <= 1'b0;
             wait_rlast_q            <= 1'b0;
             edge_trigger_q          <= 1'b0;
@@ -890,6 +927,7 @@ module rv_iommu_cdw_pc #(
             dc_fsc_q                <= dc_fsc_n;
             pc_ta_q                 <= pc_ta_n;
             pc_fsc_q                <= pc_fsc_n;
+            pc_iohgatp_q            <= pc_iohgatp_n;
             ptw_done_q              <= ptw_done_i;
             wait_rlast_q            <= wait_rlast_n;
             edge_trigger_q          <= edge_trigger_n;

--- a/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
@@ -220,7 +220,9 @@ module rv_iommu_tw_sv39x4_pc #(
     logic S1_en, S2_en;
     assign S1_en    = ((dc_base.tc.pdtv && pdtc_lu_content.fsc.mode != 4'b0000) ||
                        (!dc_base.tc.pdtv && dc_base.fsc.mode != 4'b0000)          );
-    assign S2_en    = (dc_base.iohgatp.mode != 4'b0000);
+    assign S2_en    = (dc_base.iohgatp.mode != 4'b0000 ||
+                       (dc_base.tc.pdtv && dc_base.tc.gipc &&
+                        pdtc_lu_content.iohgatp.mode != 4'b0000));
 
     // Alternative translation config for PTW implicit second-stage translations in CDW Walks
     logic   ptw_en_1S, ptw_en_2S;
@@ -480,7 +482,7 @@ module rv_iommu_tw_sv39x4_pc #(
         .cause_code_o           (ptw_cause_code     ),
 
         .en_1S_i                (ptw_en_1S          ),  // Enable signal for stage 1 translation. Defined by DC/PC
-        .en_2S_i                (ptw_en_2S          ),  // Enable signal for stage 2 translation. Defined by DC only
+        .en_2S_i                (ptw_en_2S          ),  // Enable signal for stage 2 translation. Defined by DC/PC
         .is_store_i             (is_store           ),  // Indicate whether this translation was triggered by a store or a load
         .is_rx_i                (is_rx              ),  // Read-for-execute
 
@@ -771,6 +773,7 @@ module rv_iommu_tw_sv39x4_pc #(
         .caps_msi_flat_i        (capabilities_i.msi_flat.q  ),
         .caps_amo_hwad_i        (capabilities_i.amo_hwad.q  ),
         .caps_end_i             (capabilities_i.endi.q      ),
+        .caps_gipc_i            (capabilities_i.gipc.q      ),
         .fctl_be_i              (fctl_i.be.q                ),
 
         // PC checks
@@ -805,6 +808,7 @@ module rv_iommu_tw_sv39x4_pc #(
 
         // from DC (for PC walks)
         .en_stage2_i            (S2_en              ),    // Second-stage translation is enabled
+        .gipc_i                 (dc_base.tc.gipc    ),    // GIPC is enabled
         .pdtp_ppn_i             (dc_base.fsc.ppn    ),      // PPN from DC.fsc.PPN
         .pdtp_mode_i            (dc_base.fsc.mode   ),      // PDT levels from DC.fsc.MODE
 
@@ -951,7 +955,7 @@ module rv_iommu_tw_sv39x4_pc #(
                 else begin
                     gscid           = dc_base.iohgatp.gscid;
                     pscid           = pdtc_lu_content.ta.pscid;
-                    iohgatp_ppn     = dc_base.iohgatp.ppn;
+                    iohgatp_ppn     = dc_base.tc.gipc ? pdtc_lu_content.iohgatp.ppn : dc_base.iohgatp.ppn;
                     iosatp_ppn      = pdtc_lu_content.fsc.ppn;
                     iotlb_access    = 1'b1;
                 end


### PR DESCRIPTION
The current G-stage page table resides within the device context and is only bound to one DC (Device Context). Consequently, this feature limits the DC to serve only a single virtual machine, which means G-stage table In Device Context (GIDC).

The GIPC capability [1] adds iohgatp in PC (Process Context), and makes RISC-V IOMMU support GIPC and GIDC simultaneously. This improves the virtualization scalability of heterogeneous programming in shared work queue scenarios [2].

Because RVI hasn't ratified GIPC, this patch uses custom bit fields of dc.tc & capability regs.

[1] https://github.com/riscv-non-isa/riscv-iommu/pull/413
[2] https://www.youtube.com/watch?v=-fuqzYedOb0